### PR TITLE
Minimum number of upstream servers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 
 ntp_driftfile: /var/lib/ntp/drift
-ntp_server: [0.pool.ntp.org, 1.pool.ntp.org]
+ntp_server: [0.pool.ntp.org, 1.pool.ntp.org, 2.pool.ntp.org, 3.pool.ntp.org]
 ntp_restrict:
   - "restrict -4 default kod notrap nomodify nopeer noquery"
   - "restrict -6 default kod notrap nomodify nopeer noquery"


### PR DESCRIPTION
Per the link below  the default config should really have 3-4 servers minimum to be effective.

http://support.ntp.org/bin/view/Support/SelectingOffsiteNTPServers#Section_5.3.3. 
